### PR TITLE
Add Claude Code configuration and HuggingFace workflow skill

### DIFF
--- a/.claude/skills/huggingface/SKILL.md
+++ b/.claude/skills/huggingface/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: huggingface
+description: Manage HuggingFace Hub resources (models, datasets) via CLI and Python. Use when working with HuggingFace PRs, discussions, repo metadata, or README descriptions. Key insight: the `hf` CLI does NOT support PR management—use the `huggingface_hub` Python library instead.
+---
+
+# HuggingFace Hub Management
+
+## Key Constraint
+
+The `hf` CLI supports auth, upload, download, and repo operations,
+but **not** PR/discussion management.
+For PRs, use `huggingface_hub` Python library via `uv run`.
+
+## Authentication
+
+```bash
+# Interactive login (run in separate terminal if in Claude Code)
+uvx --from huggingface_hub hf auth login
+
+# Verify
+uvx --from huggingface_hub hf auth whoami
+```
+
+## PR Operations (Python)
+
+Use heredoc pattern with `uv run`:
+
+### Create PR with description
+
+```bash
+uv run --with huggingface_hub python3 << 'PYEOF'
+from huggingface_hub import HfApi, CommitOperationAdd
+
+api = HfApi()
+result = api.create_commit(
+    repo_id='org/repo',
+    repo_type='model',  # or 'dataset'
+    operations=[CommitOperationAdd(path_in_repo='README.md', path_or_fileobj=content.encode())],
+    commit_message='Fix typo',
+    commit_description='@reviewer Please review.\n\n**Changes:**\n- Fixed typo',  # This becomes PR description
+    create_pr=True,
+)
+print(f'PR URL: {result.pr_url}')
+PYEOF
+```
+
+**Important**: Use `commit_description` for PR body—do not add a separate comment.
+
+### Push to existing PR branch
+
+```bash
+api.upload_file(
+    path_or_fileobj=content.encode(),
+    path_in_repo='README.md',
+    repo_id='org/repo',
+    repo_type='model',
+    revision='refs/pr/3',  # PR branch
+    commit_message='Update'
+)
+```
+
+### Merge PR
+
+```bash
+api.merge_pull_request(
+    repo_id='org/repo',
+    repo_type='model',
+    discussion_num=3,
+    comment='Thanks!'
+)
+```
+
+### Close PR
+
+```bash
+api.change_discussion_status(
+    repo_id='org/repo',
+    repo_type='model',
+    discussion_num=3,
+    new_status='closed',
+    comment='Closing—explanation above.'
+)
+```
+
+### Edit PR description
+
+```bash
+from huggingface_hub import get_discussion_details
+
+details = get_discussion_details('org/repo', discussion_num=3, repo_type='model')
+api.edit_discussion_comment(
+    repo_id='org/repo',
+    repo_type='model',
+    discussion_num=3,
+    comment_id=details.events[0].id,  # First event is PR description
+    new_content='Updated description'
+)
+```
+
+### List open PRs
+
+```bash
+from huggingface_hub import get_repo_discussions
+
+for d in get_repo_discussions('org/repo', repo_type='model', discussion_status='open'):
+    print(f'#{d.num}: {d.title} (PR: {d.is_pull_request})')
+```
+
+## Repo Type
+
+Always specify `repo_type`:
+- `model` — model repos
+- `dataset` — dataset repos
+- `space` — Spaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code)
+when working with code in this repository.
+
+## Commands
+
+```bash
+npm install          # Install dependencies
+npm run dev          # Development server at localhost:5173 (hot reload)
+npm run build        # TypeScript compile + Vite production build
+npm run lint         # ESLint check
+npm run preview      # Preview production build
+```
+
+## Architecture
+
+This is a React/TypeScript catalog app that aggregates BIOSCAN-ML resources
+from GitHub and HuggingFace APIs.
+It runs entirely client-side with no backend.
+
+### Data Flow
+
+Three custom hooks fetch data from external APIs on mount:
+
+- `useGitHubItems` → GitHub repos from `bioscan-ml` org
+- `useHuggingFaceModels` → Models from HuggingFace `bioscan-ml` author
+- `useHuggingFaceDatasets` → Datasets from HuggingFace `bioscan-ml` author
+
+`App.tsx` consumes these hooks and normalizes the data into a common shape
+for the `Gallery` component.
+
+### Search and Sort
+
+The `Gallery` component uses Fuse.js for fuzzy search across item names and tags.
+Sorting options: name (alphabetical), last updated, likes/stars.
+
+### UI Components
+
+Components in `src/components/ui/` are based on shadcn/ui patterns
+(Radix UI + Tailwind CSS).
+To add new components, use the shadcn CLI which copies them into the project
+for customization.
+
+### Path Aliases
+
+`@/*` maps to `./src/*` (configured in tsconfig and vite.config).


### PR DESCRIPTION
## Summary

This PR adds configuration files for [Claude Code](https://claude.ai/code) to help maintainers work with the bioscan-ml ecosystem more efficiently.

- **CLAUDE.md**: Documents build commands and architecture for this catalog app
- **HuggingFace skill**: A workflow guide for managing HuggingFace PRs, discussions, and repo metadata

## Why include this?

Managing HuggingFace resources (models, datasets) requires a different workflow than GitHub—the `hf` CLI doesn't support PR operations, so you need to use the Python library with specific patterns. This skill captures those patterns so any maintainer using Claude Code can:

- Create, merge, and close HuggingFace PRs
- Edit PR descriptions and tag reviewers
- Update README descriptions consistently

This workflow was developed while completing Issues #1, #2, and #3 (standardizing descriptions across all bioscan-ml GitHub and HuggingFace repos).

## Impact on non-Claude Code users

**None.** These files live in `.claude/` and `CLAUDE.md`—they have no effect on the build, runtime, or development workflow for anyone not using Claude Code.

## Test plan

- [x] Verified skill triggers correctly on HuggingFace-related tasks
- [x] Used workflow to complete 8 HuggingFace PRs and 16 GitHub description updates

## Demo

[View terminal output](https://gisthost.github.io/?605ddae159c62003298c933672235781)
